### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     },
     "require": {
         "php": ">=7.1.3",
-        "mailjet/mailjet-apiv3-php": "^1.2",
+        "mailjet/mailjet-apiv3-php": "^1.5.2",
         "mailjet/mailjet-swiftmailer": "^2.0",
         "symfony/config": "^4.4|^5.0",
         "symfony/console": "^4.4|^5.0",


### PR DESCRIPTION
Modification of the minimum version required for the "mailjet/mailjet-apiv3-php" bundle because in the "MailjetClient" class on the "master" branch we end up with an error "Warning: Declaration of Mailjet\MailjetBundle\Client\MailjetClient::post(array $resource, array $args = Array, array $options = Array): Mailjet\Response should be compatible with Mailjet\Client::post($resource, array $args = Array, array $options = Array)" because some types are missing.